### PR TITLE
Allow specifying existing GIDs

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,14 +38,17 @@ if [ ! -d $DEST ]; then
     mkdir -p $DEST
 fi
 
+GROUP_NAME=$(getent group "${GID}" | cut -d":" -f1)
+
 # Add a group
-if [ $GID -gt 0 ]; then
+if [ $GID -gt 0 -a -z "${GROUP_NAME}" ]; then
     addgroup -g $GID -S $GID
+    GROUP_NAME=$GID
 fi
 
 # Add a user
 if [ $UID -gt 0 ]; then
-    adduser -u $UID -D -G $GID $UID
+    adduser -u $UID -D -G $GROUP_NAME $UID
     RUN_AS=$UID
     chown $UID $AWS_S3_MOUNT
     chown $UID ${AWS_S3_AUTHFILE}


### PR DESCRIPTION
Before, using an existing GID would result in an error when creating the
user.

When the entry point script creates a new group, it uses the GID as id
and name. adduser expects the group name. If the group already existed before,
then it most likely didn't have the id as its name, so adduser fails.
Then in turn executing s3fs fails because the user is not found.

This patch detects if the group is already present and uses it in that case.