### PR TITLE
add: "-o" flag to S3FS_ARGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ parametrise the container:
 * `S3FS_DEBUG` can be set to `1` to get some debugging information from [s3fs].
 * `S3FS_ARGS` can contain some additional options to be blindly passed to
   [s3fs].
+  * options are supposed to be given comma-separated, e.g. "use_path_request_style,allow_other,default_acl=public-read"
 
   [secrets]: https://docs.docker.com/engine/swarm/secrets/
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -61,11 +61,16 @@ if [ $S3FS_DEBUG = "1" ]; then
     DEBUG_OPTS="-d -d"
 fi
 
+# Additional S3FS options
+if [ -n "$S3FS_ARGS" ]; then
+    S3FS_ARGS="-o $S3FS_ARGS"
+fi
+
 # Mount and verify that something is present. davfs2 always creates a lost+found
 # sub-directory, so we can use the presence of some file/dir as a marker to
 # detect that mounting was a success. Execute the command on success.
 
-su - $RUN_AS -c "s3fs $DEBUG_OPTS -o ${S3FS_ARGS} \
+su - $RUN_AS -c "s3fs $DEBUG_OPTS ${S3FS_ARGS} \
     -o passwd_file=${AWS_S3_AUTHFILE} \
     -o url=${AWS_S3_URL} \
     -o uid=$UID \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -65,7 +65,7 @@ fi
 # sub-directory, so we can use the presence of some file/dir as a marker to
 # detect that mounting was a success. Execute the command on success.
 
-su - $RUN_AS -c "s3fs $DEBUG_OPTS ${S3FS_ARGS} \
+su - $RUN_AS -c "s3fs $DEBUG_OPTS -o ${S3FS_ARGS} \
     -o passwd_file=${AWS_S3_AUTHFILE} \
     -o url=${AWS_S3_URL} \
     -o uid=$UID \


### PR DESCRIPTION
This PR refers to my comment on #11 .

It adds a `-o` flag to the `S3FS_ARGS` arguments so they get handled as `s3fs` options automatically, without users having to work around it with `S3FS_ARGS="-o {options}"`.