### PR TITLE
Mime type detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine AS build
 
-ARG S3FS_VERSION=v1.86
+ARG S3FS_VERSION=v1.89
 
 RUN apk --no-cache add \
     ca-certificates \
@@ -12,6 +12,7 @@ RUN apk --no-cache add \
     autoconf \
     libxml2-dev \
     libressl-dev \
+    mailcap \
     fuse-dev \
     curl-dev && \
   git clone https://github.com/s3fs-fuse/s3fs-fuse.git && \
@@ -52,6 +53,7 @@ ENV S3FS_ARGS=
 RUN mkdir /opt/s3fs && \
     apk --no-cache add \
       ca-certificates \
+      mailcap \
       fuse \
       libxml2 \
       libcurl \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
   s3fs:
     container_name: s3fs
-    image: efrecon/s3fs:1.86
+    image: efrecon/s3fs:1.89
     restart: unless-stopped
     cap_add:
       - SYS_ADMIN


### PR DESCRIPTION
Mime types were not being detected as the image does not have a file at `/etc/mime.types` - see https://github.com/s3fs-fuse/s3fs-fuse/blob/v1.89/COMPILATION.md. This was causing all files to be uploaded with a mime type of `application/octet-stream`. So I installed `mailcap` to provide mime types, and now files are detected correctly.