### PR TITLE
Complete usage of $DEST and RUN_AS user for first 'ls'

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ parametrise the container:
   `AWS_S3_AUTHFILE` is empty.
 * `AWS_S3_URL` is the URL to the Amazon service. This can be used to mount
   external services that implement a compatible API.
-* `AWS_S3_MOUNT` is the location within the container where to mounte the
+* `AWS_S3_MOUNT` is the location within the container where to mount the
   WebDAV resource. This defaults to `/opt/s3fs/bucket` and is not really meant to
   be changed.
 * `UID` is the user ID for the owner of the share inside the container.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -34,8 +34,8 @@ if [ -n "${AWS_S3_SECRET_ACCESS_KEY}" ]; then
 fi
 
 # Create destination directory if it does not exist.
-if [ ! -d $DEST ]; then
-    mkdir -p $DEST
+if [ ! -d "${DEST}" ]; then
+    mkdir -p "${DEST}"
 fi
 
 GROUP_NAME=$(getent group "${GID}" | cut -d":" -f1)
@@ -50,7 +50,7 @@ fi
 if [ $UID -gt 0 ]; then
     adduser -u $UID -D -G $GROUP_NAME $UID
     RUN_AS=$UID
-    chown $UID:$GID $AWS_S3_MOUNT
+    chown $UID:$GID "${DEST}"
     chown $UID:$GID ${AWS_S3_AUTHFILE}
     chown $UID:$GID /opt/s3fs
 fi
@@ -75,15 +75,15 @@ su - $RUN_AS -c "s3fs $DEBUG_OPTS ${S3FS_ARGS} \
     -o url=${AWS_S3_URL} \
     -o uid=$UID \
     -o gid=$GID \
-    ${AWS_S3_BUCKET} ${AWS_S3_MOUNT}"
+    ${AWS_S3_BUCKET} ${DEST}"
 
 # s3fs can claim to have a mount even though it didn't succeed.
 # Doing an operation actually forces it to detect that and remove the mount.
-ls "${AWS_S3_MOUNT}"
+su - $RUN_AS -c "ls ${DEST}"
 
-mounted=$(mount | grep fuse.s3fs | grep "${AWS_S3_MOUNT}")
+mounted=$(mount | grep fuse.s3fs | grep "${DEST}")
 if [ -n "${mounted}" ]; then
-    echo "Mounted bucket ${AWS_S3_BUCKET} onto ${AWS_S3_MOUNT}"
+    echo "Mounted bucket ${AWS_S3_BUCKET} onto ${DEST}"
     exec "$@"
 else
     echo "Mount failure"


### PR DESCRIPTION
* When running the container as non root UIDs the 'ls' in the the
docker-entrypoint.sh would not have the correct privledges and error.
* Noticed the usage of $DEST was incomplete and sporadic.
* Fix readme typo.