### PR TITLE
secure alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3 AS build
+FROM alpine:3.15.2 AS build
 
 ARG S3FS_VERSION=v1.91
 
@@ -23,7 +23,7 @@ RUN apk --no-cache add \
   make -j && \
   make install
 
-FROM alpine:3
+FROM alpine:3.15.2
 
 # Metadata
 LABEL MAINTAINER=efrecon+github@gmail.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.2 AS build
+FROM alpine:3.15.3 AS build
 
 ARG S3FS_VERSION=v1.91
 
@@ -23,7 +23,7 @@ RUN apk --no-cache add \
   make -j && \
   make install
 
-FROM alpine:3.15.2
+FROM alpine:3.15.3
 
 # Metadata
 LABEL MAINTAINER=efrecon+github@gmail.com


### PR DESCRIPTION
it is recommanded to always fix the base image of the dockerfile . 

Here is the actual scan of the image build with just `alpine:3` with trivy: 

```log
efrecon/s3fs:latest (alpine 3.12.0)
===================================
Total: 68 (UNKNOWN: 0, LOW: 6, MEDIUM: 18, HIGH: 40, CRITICAL: 4)

+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
|   LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| apk-tools    | CVE-2021-36159   | CRITICAL | 2.10.5-r1         | 2.10.7-r0     | libfetch before 2021-07-26, as        |
|              |                  |          |                   |               | used in apk-tools, xbps, and          |
|              |                  |          |                   |               | other products, mishandles...         |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-36159 |
+              +------------------+----------+                   +---------------+---------------------------------------+
|              | CVE-2021-30139   | HIGH     |                   | 2.10.6-r0     | In Alpine Linux apk-tools             |
|              |                  |          |                   |               | before 2.12.5, the tarball            |
|              |                  |          |                   |               | parser allows a buffer...             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-30139 |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| busybox      | CVE-2021-28831   |          | 1.31.1-r16        | 1.31.1-r20    | busybox: invalid free or segmentation |
|              |                  |          |                   |               | fault via malformed gzip data         |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-28831 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-42378   |          |                   | 1.31.1-r21    | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42378 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42379   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42379 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42380   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42380 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42381   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42381 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42382   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42382 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42383   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42383 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42384   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42384 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42385   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42385 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42386   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42386 |
+              +------------------+----------+                   +               +---------------------------------------+
|              | CVE-2021-42374   | MEDIUM   |                   |               | busybox: out-of-bounds read           |
|              |                  |          |                   |               | in unlzma applet leads to             |
|              |                  |          |                   |               | information leak and denial...        |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42374 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| libcrypto1.1 | CVE-2021-3711    | CRITICAL | 1.1.1g-r0         | 1.1.1l-r0     | openssl: SM2 Decryption               |
|              |                  |          |                   |               | Buffer Overflow                       |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3711  |
+              +------------------+----------+                   +---------------+---------------------------------------+
|              | CVE-2021-23840   | HIGH     |                   | 1.1.1j-r0     | openssl: integer                      |
|              |                  |          |                   |               | overflow in CipherUpdate              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-23840 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-3450    |          |                   | 1.1.1k-r0     | openssl: CA certificate check         |
|              |                  |          |                   |               | bypass with X509_V_FLAG_X509_STRICT   |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3450  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-3712    |          |                   | 1.1.1l-r0     | openssl: Read buffer overruns         |
|              |                  |          |                   |               | processing ASN.1 strings              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3712  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2022-0778    |          |                   | 1.1.1n-r0     | openssl: Infinite loop in             |
|              |                  |          |                   |               | BN_mod_sqrt() reachable               |
|              |                  |          |                   |               | when parsing certificates             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-0778  |
+              +------------------+----------+                   +---------------+---------------------------------------+
|              | CVE-2020-1971    | MEDIUM   |                   | 1.1.1i-r0     | openssl: EDIPARTYNAME                 |
|              |                  |          |                   |               | NULL pointer de-reference             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-1971  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-23841   |          |                   | 1.1.1j-r0     | openssl: NULL pointer dereference     |
|              |                  |          |                   |               | in X509_issuer_and_serial_hash()      |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-23841 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-3449    |          |                   | 1.1.1k-r0     | openssl: NULL pointer dereference     |
|              |                  |          |                   |               | in signature_algorithms processing    |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3449  |
+              +------------------+----------+                   +---------------+---------------------------------------+
|              | CVE-2021-23839   | LOW      |                   | 1.1.1j-r0     | openssl: incorrect SSLv2              |
|              |                  |          |                   |               | rollback protection                   |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-23839 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| libcurl      | CVE-2021-22945   | CRITICAL | 7.69.1-r0         | 7.79.0-r0     | curl: use-after-free and              |
|              |                  |          |                   |               | double-free in MQTT sending           |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-22945 |
+              +------------------+----------+                   +---------------+---------------------------------------+
|              | CVE-2020-8169    | HIGH     |                   | 7.69.1-r1     | libcurl: partial password             |
|              |                  |          |                   |               | leak over DNS on HTTP redirect        |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-8169  |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2020-8177    |          |                   |               | curl: Incorrect argument              |
|              |                  |          |                   |               | check can allow remote servers        |
|              |                  |          |                   |               | to overwrite local files...           |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-8177  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2020-8231    |          |                   | 7.69.1-r2     | curl: Expired pointer                 |
|              |                  |          |                   |               | dereference via multi API with        |
|              |                  |          |                   |               | CURLOPT_CONNECT_ONLY option set       |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-8231  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2020-8285    |          |                   | 7.69.1-r3     | curl: Malicious FTP server can        |
|              |                  |          |                   |               | trigger stack overflow when           |
|              |                  |          |                   |               | CURLOPT_CHUNK_BGN_FUNCTION            |
|              |                  |          |                   |               | is used...                            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-8285  |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2020-8286    |          |                   |               | curl: Inferior OCSP verification      |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-8286  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-22901   |          |                   | 7.77.0-r0     | curl: Use-after-free in               |
|              |                  |          |                   |               | TLS session handling when             |
|              |                  |          |                   |               | using OpenSSL TLS backend             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-22901 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-22946   |          |                   | 7.79.0-r0     | curl: Requirement to use              |
|              |                  |          |                   |               | TLS not properly enforced             |
|              |                  |          |                   |               | for IMAP, POP3, and...                |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-22946 |
+              +------------------+----------+                   +---------------+---------------------------------------+
|              | CVE-2021-22876   | MEDIUM   |                   | 7.76.0-r0     | curl: Leak of authentication          |
|              |                  |          |                   |               | credentials in URL                    |
|              |                  |          |                   |               | via automatic Referer                 |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-22876 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-22922   |          |                   | 7.78.0-r0     | curl: Content not matching hash       |
|              |                  |          |                   |               | in Metalink is not being discarded    |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-22922 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-22923   |          |                   |               | curl: Metalink download               |
|              |                  |          |                   |               | sends credentials                     |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-22923 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-22925   |          |                   |               | curl: Incorrect fix for               |
|              |                  |          |                   |               | CVE-2021-22898 TELNET                 |
|              |                  |          |                   |               | stack contents disclosure             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-22925 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-22947   |          |                   | 7.79.0-r0     | curl: Server responses                |
|              |                  |          |                   |               | received before STARTTLS              |
|              |                  |          |                   |               | processed after TLS handshake         |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-22947 |
+              +------------------+----------+                   +---------------+---------------------------------------+
|              | CVE-2020-8284    | LOW      |                   | 7.74.0-r0     | curl: FTP PASV command                |
|              |                  |          |                   |               | response can cause curl               |
|              |                  |          |                   |               | to connect to arbitrary...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-8284  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-22890   |          |                   | 7.76.0-r0     | curl: TLS 1.3 session ticket          |
|              |                  |          |                   |               | mix-up with HTTPS proxy host          |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-22890 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-22898   |          |                   | 7.77.0-r0     | curl: TELNET stack                    |
|              |                  |          |                   |               | contents disclosure                   |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-22898 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-22924   |          |                   | 7.78.0-r0     | curl: Bad connection reuse            |
|              |                  |          |                   |               | due to flawed path name checks        |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-22924 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| libssl1.1    | CVE-2021-3711    | CRITICAL | 1.1.1g-r0         | 1.1.1l-r0     | openssl: SM2 Decryption               |
|              |                  |          |                   |               | Buffer Overflow                       |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3711  |
+              +------------------+----------+                   +---------------+---------------------------------------+
|              | CVE-2021-23840   | HIGH     |                   | 1.1.1j-r0     | openssl: integer                      |
|              |                  |          |                   |               | overflow in CipherUpdate              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-23840 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-3450    |          |                   | 1.1.1k-r0     | openssl: CA certificate check         |
|              |                  |          |                   |               | bypass with X509_V_FLAG_X509_STRICT   |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3450  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-3712    |          |                   | 1.1.1l-r0     | openssl: Read buffer overruns         |
|              |                  |          |                   |               | processing ASN.1 strings              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3712  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2022-0778    |          |                   | 1.1.1n-r0     | openssl: Infinite loop in             |
|              |                  |          |                   |               | BN_mod_sqrt() reachable               |
|              |                  |          |                   |               | when parsing certificates             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-0778  |
+              +------------------+----------+                   +---------------+---------------------------------------+
|              | CVE-2020-1971    | MEDIUM   |                   | 1.1.1i-r0     | openssl: EDIPARTYNAME                 |
|              |                  |          |                   |               | NULL pointer de-reference             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-1971  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-23841   |          |                   | 1.1.1j-r0     | openssl: NULL pointer dereference     |
|              |                  |          |                   |               | in X509_issuer_and_serial_hash()      |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-23841 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-3449    |          |                   | 1.1.1k-r0     | openssl: NULL pointer dereference     |
|              |                  |          |                   |               | in signature_algorithms processing    |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3449  |
+              +------------------+----------+                   +---------------+---------------------------------------+
|              | CVE-2021-23839   | LOW      |                   | 1.1.1j-r0     | openssl: incorrect SSLv2              |
|              |                  |          |                   |               | rollback protection                   |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-23839 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| libxml2      | CVE-2021-3517    | HIGH     | 2.9.10-r4         | 2.9.10-r6     | libxml2: Heap-based buffer overflow   |
|              |                  |          |                   |               | in xmlEncodeEntitiesInternal()        |
|              |                  |          |                   |               | in entities.c                         |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3517  |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-3518    |          |                   |               | libxml2: Use-after-free in            |
|              |                  |          |                   |               | xmlXIncludeDoProcess() in xinclude.c  |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3518  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2022-23308   |          |                   | 2.9.13-r0     | libxml2: Use-after-free               |
|              |                  |          |                   |               | of ID and IDREF attributes            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-23308 |
+              +------------------+----------+                   +---------------+---------------------------------------+
|              | CVE-2020-24977   | MEDIUM   |                   | 2.9.10-r5     | libxml2: Buffer overflow              |
|              |                  |          |                   |               | vulnerability in                      |
|              |                  |          |                   |               | xmlEncodeEntitiesInternal()           |
|              |                  |          |                   |               | in entities.c                         |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-24977 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-3537    |          |                   | 2.9.10-r6     | libxml2: NULL pointer dereference     |
|              |                  |          |                   |               | when post-validating mixed            |
|              |                  |          |                   |               | content parsed in recovery mode...    |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3537  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-3541    |          |                   | 2.9.12-r0     | libxml2: Exponential entity           |
|              |                  |          |                   |               | expansion attack bypasses all         |
|              |                  |          |                   |               | existing protection mechanisms        |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3541  |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| musl         | CVE-2020-28928   |          | 1.1.24-r8         | 1.1.24-r10    | In musl libc through 1.2.1,           |
|              |                  |          |                   |               | wcsnrtombs mishandles particular      |
|              |                  |          |                   |               | combinations of destination buffer... |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-28928 |
+--------------+                  +          +                   +               +                                       +
| musl-utils   |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| ssl_client   | CVE-2021-28831   | HIGH     | 1.31.1-r16        | 1.31.1-r20    | busybox: invalid free or segmentation |
|              |                  |          |                   |               | fault via malformed gzip data         |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-28831 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-42378   |          |                   | 1.31.1-r21    | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42378 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42379   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42379 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42380   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42380 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42381   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42381 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42382   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42382 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42383   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42383 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42384   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42384 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42385   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42385 |
+              +------------------+          +                   +               +---------------------------------------+
|              | CVE-2021-42386   |          |                   |               | busybox: use-after-free in            |
|              |                  |          |                   |               | awk applet leads to denial            |
|              |                  |          |                   |               | of service and possibly...            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42386 |
+              +------------------+----------+                   +               +---------------------------------------+
|              | CVE-2021-42374   | MEDIUM   |                   |               | busybox: out-of-bounds read           |
|              |                  |          |                   |               | in unlzma applet leads to             |
|              |                  |          |                   |               | information leak and denial...        |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42374 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| zlib         | CVE-2018-25032   | HIGH     | 1.2.11-r3         | 1.2.12-r0     | zlib: A flaw in zlib-1.2.11           |
|              |                  |          |                   |               | when compressing (not                 |
|              |                  |          |                   |               | decompressing!) certain inputs.       |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-25032 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+

```
And Below the scan with a fixed version of `alpine:3.15.3`:
```log
s3fs-client:beta1 (alpine 3.15.3)
=================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

```
