### PR TITLE
Don't use `ls` on container start.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -128,7 +128,7 @@ su - $RUN_AS -c "s3fs $DEBUG_OPTS ${S3FS_ARGS} \
 
 # s3fs can claim to have a mount even though it didn't succeed. Doing an
 # operation actually forces it to detect that and remove the mount.
-su - $RUN_AS -c "ls ${AWS_S3_MOUNT}"
+su - $RUN_AS -c "touch ${AWS_S3_MOUNT}/.s3fs-test.txt && rm ${AWS_S3_MOUNT}/.s3fs-test.txt"
 
 if healthcheck.sh; then
     echo "Mounted bucket ${AWS_S3_BUCKET} onto ${AWS_S3_MOUNT}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -128,7 +128,7 @@ su - $RUN_AS -c "s3fs $DEBUG_OPTS ${S3FS_ARGS} \
 
 # s3fs can claim to have a mount even though it didn't succeed. Doing an
 # operation actually forces it to detect that and remove the mount.
-su - $RUN_AS -c "touch ${AWS_S3_MOUNT}/.s3fs-test.txt && rm ${AWS_S3_MOUNT}/.s3fs-test.txt"
+su - $RUN_AS -c "stat ${AWS_S3_MOUNT}"
 
 if healthcheck.sh; then
     echo "Mounted bucket ${AWS_S3_BUCKET} onto ${AWS_S3_MOUNT}"


### PR DESCRIPTION
If you have a bucket that contains many files, `ls` can be extremely slow, because it has to read everything in the directory and then sort it. This is all largely pointless, since we just want to run an operation to force it to mount the directory. In this case, I've replaced the `ls` with a `touch` command that creates and then deletes an empty file, which hopefully would have the same effect.